### PR TITLE
Add script to pre-create folders and example files

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -10,6 +10,7 @@
     "stopOnFirstFail": true,
     "skipJsErrors": true,
     "skipUncaughtErrors": true,
+    "concurrency": 2,
     "selectorTimeout": 3000,
     "assertionTimeout": 1000,
     "pageLoadTimeout": 1000,

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ to your `package.json` just run:
 npm install testcafe-cucumber-steps cucumber testcafe gherkin-testcafe --save-dev
 ```
 
+If you also want to have pre-created config (`./.testcaferc.json`) and example
+test files (`./tests/test-example.feature, ./tests/page-model/test-page-example.js`
+) - just run:
+```
+node node_modules/testcafe-cucumber-steps/utils/prepare.js
+```
+
 ## Importing and running in CLI
 It is quite simple to use - to get access to all Cucumber steps defined in this
 package just specify the path to this package when launching tests (also use

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ to all step definitions and tests should be specified inside the array in `src`)
     "stopOnFirstFail": true,
     "skipJsErrors": true,
     "skipUncaughtErrors": true,
+    "concurrency": 2,
     "selectorTimeout": 3000,
     "assertionTimeout": 1000,
     "pageLoadTimeout": 1000,

--- a/utils/prepare.js
+++ b/utils/prepare.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const pathToTestsDir = path.join(__dirname, '../../../tests');
+const pathToPageObjectsDir = path.join(pathToTestsDir, '/page-model');
+const pathToTestExample = path.join(pathToTestsDir, 'test-example.feature');
+const testExampleContent = `@Fast
+
+Feature: Running Cucumber with TestCafe - test feature example
+  As a user of Google
+  I should be able to see the About page
+  to learn more about Google
+
+  Scenario: Google's About page title should contain "Google"
+    Given I go to URL "https://www.google.com/"
+    When I click linkAbout from test-page-example page
+    Then the title should contain "Google"`;
+const pathToPageObjectsExample = path.join(pathToPageObjectsDir,
+    'test-page-example.js');
+const pageObjectsExampleContent = `'use strict';
+
+module.exports = (function () {
+
+    let testPage = {
+
+        linkAbout: 'a[href*="about.google"]'
+
+    };
+
+    return testPage;
+
+})();`;
+const pathToConfigExample = path.join(pathToTestsDir, '.testcaferc.json');
+const configExampleContent = `{
+    "browsers": "chrome",
+    "src": ["node_modules/testcafe-cucumber-steps/index.js", "tests/**/*.js", "tests/**/*.feature"],
+    "screenshots": {
+        "path": "tests/screenshots/",
+        "takeOnFails": true,
+        "pathPattern": "\${DATE}_\${TIME}/test-\${TEST_INDEX}/\${USERAGENT}/\${FILE_INDEX}.png"
+    },
+    "quarantineMode": false,
+    "stopOnFirstFail": true,
+    "skipJsErrors": true,
+    "skipUncaughtErrors": true,
+    "selectorTimeout": 3000,
+    "assertionTimeout": 1000,
+    "pageLoadTimeout": 1000,
+    "disablePageCaching": true
+}`;
+
+const createFile = (filePath, fileContent) => {
+    fs.writeFileSync(filePath, fileContent, (error) => {
+        if (error) {
+            console.log(`Error creating a file ${filePath}:`, error);
+        }
+    });
+};
+
+const testsDirExists = fs.existsSync(pathToTestsDir);
+const pageObjectsDirExists = fs.existsSync(pathToPageObjectsDir);
+
+if (!testsDirExists) {
+    fs.mkdirSync(pathToTestsDir);
+    fs.mkdirSync(pathToPageObjectsDir);
+} else if (testsDirExists && !pageObjectsDirExists) {
+    fs.mkdirSync(pathToPageObjectsDir);
+} else {
+    console.log('"tests" and "page-model" folders are already in place');
+}
+
+createFile(pathToTestExample, testExampleContent);
+createFile(pathToPageObjectsExample, pageObjectsExampleContent);
+createFile(pathToConfigExample, configExampleContent);
+

--- a/utils/prepare.js
+++ b/utils/prepare.js
@@ -57,6 +57,7 @@ const createFile = (filePath, fileContent) => {
             console.log(`Error creating a file ${filePath}:`, error);
         }
     });
+    console.log(`Created file: ${filePath}`);
 };
 
 const testsDirExists = fs.existsSync(pathToTestsDir);
@@ -67,8 +68,6 @@ if (!testsDirExists) {
     fs.mkdirSync(pathToPageObjectsDir);
 } else if (testsDirExists && !pageObjectsDirExists) {
     fs.mkdirSync(pathToPageObjectsDir);
-} else {
-    console.log('"tests" and "page-model" folders are already in place');
 }
 
 createFile(pathToTestExample, testExampleContent);

--- a/utils/prepare.js
+++ b/utils/prepare.js
@@ -32,7 +32,7 @@ module.exports = (function () {
     return testPage;
 
 })();`;
-const pathToConfigExample = path.join(pathToTestsDir, '.testcaferc.json');
+const pathToConfigExample = path.join(pathToTestsDir, '../', '.testcaferc.json');
 const configExampleContent = `{
     "browsers": "chrome",
     "src": ["node_modules/testcafe-cucumber-steps/index.js", "tests/**/*.js", "tests/**/*.feature"],

--- a/utils/prepare.js
+++ b/utils/prepare.js
@@ -10,12 +10,13 @@ const testExampleContent = `@Fast
 
 Feature: Running Cucumber with TestCafe - test feature example
   As a user of Google
-  I should be able to see the About page
+  I should be able to see the Products page
   to learn more about Google
 
-  Scenario: Google's About page title should contain "Google"
+  Scenario: Google's Products page title should contain "Google"
     Given I go to URL "https://www.google.com/"
     When I click linkAbout from test-page-example page
+    And I click linkOurProducts from test-page-example page
     Then the title should contain "Google"`;
 const pathToPageObjectsExample = path.join(pathToPageObjectsDir,
     'test-page-example.js');
@@ -25,9 +26,12 @@ module.exports = (function () {
 
     let testPage = {
 
-        linkAbout: 'a[href*="about.google"]'
+        linkAbout: 'a[href*="about.google"]',
+        header: '.header'
 
     };
+
+    testPage.linkOurProducts = \`\${testPage.header} a[title="Our products"]\`;
 
     return testPage;
 
@@ -45,6 +49,7 @@ const configExampleContent = `{
     "stopOnFirstFail": true,
     "skipJsErrors": true,
     "skipUncaughtErrors": true,
+    "concurrency": 2,
     "selectorTimeout": 3000,
     "assertionTimeout": 1000,
     "pageLoadTimeout": 1000,


### PR DESCRIPTION
**This pull request adds script to pre-create folders and example files**

Also:
- Fix the placement of `.testcaferc.json` (it should be in a root folder to work properly)