### PR TITLE
Fix 'text should be', 'text should contain' steps to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,25 +330,25 @@ window/tab equals to the text (provided in "" as a string).
 24. `"..."."..." text should be "..."` - verify that text of the element
 (provided in **"page"."object"** as CSS selector) equals to the text (provided
 in "" as a string).
-- `... text from ... should be "..."` - verify that text of the element
+- `... from ... text should be "..."` - verify that text of the element
 (provided in **object** from **page** as CSS selector) equals to the text
 (provided in "" as a string).
 - `"..."."..." text should be "..."."..."` - verify that text of the element
 (provided in **"page1"."object1"** as CSS selector) equals to the text (provided
 in **"page2"."object2"**).
-- `... text from ... should be ... from ...` - verify that text of the
+- `... from ... text should be ... from ...` - verify that text of the
 element (provided in **object1** from **page1** as CSS selector) equals to the
 text (provided in **object2** from **page2**).
 25. `"..."."..." text should contain "..."` - verify that text of the element
 (provided in **"page"."object"** as CSS selector) contains the text (provided in
 "" as a string).
-- `... text from ... should contain "..."` - verify that text of the
+- `... from ... text should contain "..."` - verify that text of the
 element (provided in **object** from **page** as CSS selector) contains the text
 (provided in "" as a string).
 - `"..."."..." text should contain "..."."..."` - verify that text of the
 element (provided in **"page1"."object1"** as CSS selector) contains the text
 (provided in **"page2"."object2"**).
-- `... text from ... should contain ... from ...` - verify that text
+- `... from ... text should contain ... from ...` - verify that text
 of the element (provided in **object1** from **page1** as CSS selector) contains
 the text (provided in **object2** from **page2**).
 26. `URL should be "..."` - verify that URL of the current page equals to the

--- a/index.js
+++ b/index.js
@@ -484,7 +484,7 @@ Then('{string}.{string} text should be {string}', async function (
     await t.expect(Selector(elem).innerText).eql(text);
 });
 
-Then('{word} text from {word}( page) should be {string}', async function (
+Then('{word} from {word}( page) text should be {string}', async function (
     t, [element, page, text]
 ) {
     const elem = getElement(page, element);
@@ -502,7 +502,7 @@ Then('{string}.{string} text should be {string}.{string}', async function (
 });
 
 Then(
-    '{word} text from {word}( page) should be {word} from {word}( page)',
+    '{word} from {word}( page) text should be {word} from {word}( page)',
     async function (t, [element1, page1, element2, page2]) {
         const elem = getElement(page1, element1);
 
@@ -519,7 +519,7 @@ Then('{string}.{string} text should contain {string}', async function (
     await t.expect(Selector(elem).innerText).contains(text);
 });
 
-Then('{word} text from {word}( page) should contain {string}', async function (
+Then('{word} from {word}( page) text should contain {string}', async function (
     t, [element, page, text]
 ) {
     const elem = getElement(page, element);
@@ -537,7 +537,7 @@ Then('{string}.{string} text should contain {string}.{string}', async function (
 });
 
 Then(
-    '{word} text from {word}( page) should contain {word} from {word}( page)',
+    '{word} from {word}( page) text should contain {word} from {word}( page)',
     async function (t, [element1, page1, element2, page2]) {
         const elem = getElement(page1, element1);
 

--- a/tests/test1-I.feature
+++ b/tests/test1-I.feature
@@ -110,7 +110,7 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 1
     When I go to "test2-page"."pageTest2"
     And I type "Green" in inputColors from test2-page page
     And I wait and click "test2-page"."inputColors"
-    Then blockInputColor text from test2-page page should be "Green"
+    Then blockInputColor from test2-page page text should be "Green"
 
   Scenario: 'I type' "Gold" (page object) text inside input should get this text typed in, 'text should be' should verify the text
     When I go to "test2-page"."pageTest2"
@@ -122,7 +122,7 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 1
     When I go to "test2-page"."pageTest2"
     And I type textGold from test2-page page in inputColors from test2-page page
     And I wait and click "test2-page"."inputColors"
-    Then blockInputColor text from test2-page page should be textGold from test2-page page
+    Then blockInputColor from test2-page page text should be textGold from test2-page page
 
   Scenario: 'I clear and type' "Green" (string) text inside input should overwrite the text
     Given I go to "test2-page"."pageTest2"
@@ -134,7 +134,7 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 1
     Given I go to "test2-page"."pageTest2"
     And I type "Yellow" in inputColors from test2-page page
     When I clear inputColors from test2-page page and type "Green"
-    Then blockInputColor text from test2-page page should be "Green"
+    Then blockInputColor from test2-page page text should be "Green"
 
   Scenario: 'I clear and type' "Gold" (page object) text inside input should overwrite the text
     Given I go to "test2-page"."pageTest2"
@@ -146,7 +146,7 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 1
     Given I go to "test2-page"."pageTest2"
     And I type textIndigo from test2-page page in inputColors from test2-page page
     When I clear inputColors from test2-page page and type textGold from test2-page page
-    Then blockInputColor text from test2-page page should be textGold from test2-page page
+    Then blockInputColor from test2-page page text should be textGold from test2-page page
 
   Scenario: 'I select' "Green" (string) option text inside select dropdown should get this option selected, 'text should be' should verify the text
     Given I go to "test2-page"."pageTest2"
@@ -156,7 +156,7 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 1
   Scenario: 'I select' "Green" (string) option text inside select dropdown should get this option selected, 'text should be' should verify the text (text style step)
     Given I go to "test2-page"."pageTest2"
     When I select "Green" in dropdownColors from test2-page page
-    Then blockDropdownColor text from test2-page page should be "green"
+    Then blockDropdownColor from test2-page page text should be "green"
 
   Scenario: 'I select' "Gold" (page object) option text inside select dropdown should get this option selected, 'text should be' should verify the text
     Given I go to "test2-page"."pageTest2"
@@ -166,4 +166,4 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 1
   Scenario: 'I select' "Gold" (page object) option text inside select dropdown should get this option selected, 'text should be' should verify the text (text style step)
     Given I go to "test2-page"."pageTest2"
     When I select textGold from test2-page page in dropdownColors from test2-page page
-    Then blockDropdownColor text from test2-page page should be textGold from test2-page page
+    Then blockDropdownColor from test2-page page text should be textGold from test2-page page

--- a/tests/test1-user.feature
+++ b/tests/test1-user.feature
@@ -110,7 +110,7 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 1
     When user goes to "test2-page"."pageTest2"
     And user types "Green" in inputColors from test2-page
     And user waits and clicks "test2-page"."inputColors"
-    Then blockInputColor text from test2-page should be "Green"
+    Then blockInputColor from test2-page text should be "Green"
 
   Scenario: 'user types' "Gold" (page object) text inside input should get this text typed in, 'text should be' should verify the text
     When user goes to "test2-page"."pageTest2"
@@ -122,7 +122,7 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 1
     When user goes to "test2-page"."pageTest2"
     And user types textGold from test2-page in inputColors from test2-page
     And user waits and clicks "test2-page"."inputColors"
-    Then blockInputColor text from test2-page should be textGold from test2-page
+    Then blockInputColor from test2-page text should be textGold from test2-page
 
   Scenario: 'user clears and types' "Green" (string) text inside input should overwrite the text
     Given user goes to "test2-page"."pageTest2"
@@ -134,7 +134,7 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 1
     Given user goes to "test2-page"."pageTest2"
     And user types "Yellow" in inputColors from test2-page
     When user clears inputColors from test2-page and types "Green"
-    Then blockInputColor text from test2-page should be "Green"
+    Then blockInputColor from test2-page text should be "Green"
 
   Scenario: 'user clears and types' "Gold" (page object) text inside input should overwrite the text
     Given user goes to "test2-page"."pageTest2"
@@ -146,7 +146,7 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 1
     Given user goes to "test2-page"."pageTest2"
     And user types textIndigo from test2-page in inputColors from test2-page
     When user clears inputColors from test2-page and types textGold from test2-page
-    Then blockInputColor text from test2-page should be textGold from test2-page
+    Then blockInputColor from test2-page text should be textGold from test2-page
 
   Scenario: 'user selects' "Green" (string) option text inside select dropdown should get this option selected, 'text should be' should verify the text
     Given user goes to "test2-page"."pageTest2"
@@ -156,7 +156,7 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 1
   Scenario: 'user selects' "Green" (string) option text inside select dropdown should get this option selected, 'text should be' should verify the text (text style step)
     Given user goes to "test2-page"."pageTest2"
     When user selects "Green" in dropdownColors from test2-page
-    Then blockDropdownColor text from test2-page should be "green"
+    Then blockDropdownColor from test2-page text should be "green"
 
   Scenario: 'user selects' "Gold" (page object) option text inside select dropdown should get this option selected, 'text should be' should verify the text
     Given user goes to "test2-page"."pageTest2"
@@ -166,4 +166,4 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 1
   Scenario: 'user selects' "Gold" (page object) option text inside select dropdown should get this option selected, 'text should be' should verify the text (text style step)
     Given user goes to "test2-page"."pageTest2"
     When user selects textGold from test2-page in dropdownColors from test2-page
-    Then blockDropdownColor text from test2-page should be textGold from test2-page
+    Then blockDropdownColor from test2-page text should be textGold from test2-page

--- a/tests/test2-I.feature
+++ b/tests/test2-I.feature
@@ -8,22 +8,22 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 2
   Scenario: 'I log in with l: and p: and click' should show credentials that were submitted for logging in
     Given I go to "test2-page"."pageTest2"
     When I log in with l: "testUser" in "test2-page"."inputUsername" and p: "1111" in "test2-page"."inputPassword" and click "test2-page"."buttonLogin"
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'I log in with l: and p: and click' should show credentials that were submitted for logging in (text style step)
     Given I go to "test2-page"."pageTest2"
     When I log in with l: "testUser" in inputUsername from test2-page and p: "1111" in inputPassword from test2-page and click buttonLogin from test2-page
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'I log in with l: and p: and click' should show credentials that were submitted for logging in (Page Object style step)
     Given I go to "test2-page"."pageTest2"
     When I log in with l: "test2-page"."loginTest2" in "test2-page"."inputUsername" and p: "test2-page"."passwordTest2" in "test2-page"."inputPassword" and click "test2-page"."buttonLogin"
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'I log in with l: and p: and click' should show credentials that were submitted for logging in (text style step)
     Given I go to "test2-page"."pageTest2"
     When I log in with l: loginTest2 from test2-page in inputUsername from test2-page and p: passwordTest2 from test2-page in inputPassword from test2-page and click buttonLogin from test2-page
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'I move to' element should trigger its hovered state, 'text should contain' should verify the text
     When I go to URL "http://localhost:8001/test1.html"
@@ -33,7 +33,7 @@ Feature: Running Cucumber with TestCafe - test "I ..." steps feature 2
   Scenario: 'I move to' element should trigger its hovered state, 'text should contain' should verify the text (text style step)
     When I go to URL "http://localhost:8001/test1.html"
     And I move to titleTest1 from test-page page
-    Then blockTextTest text from test-page page should contain txtTest1 from test-page page
+    Then blockTextTest from test-page page text should contain txtTest1 from test-page page
 
   Scenario: 'I move to with an offset' should trigger element's hovered state
     When I go to URL "http://localhost:8001/test1.html"

--- a/tests/test2-user.feature
+++ b/tests/test2-user.feature
@@ -8,22 +8,22 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 2
   Scenario: 'user logs in with l: and p: and clicks' should show credentials that were submitted for logging in
     Given user goes to "test2-page"."pageTest2"
     When user logs in with l: "testUser" in "test2-page"."inputUsername" and p: "1111" in "test2-page"."inputPassword" and clicks "test2-page"."buttonLogin"
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'user logs in with l: and p: and clicks' should show credentials that were submitted for logging in (text style step)
     Given user goes to "test2-page"."pageTest2"
     When user logs in with l: "testUser" in inputUsername from test2-page and p: "1111" in inputPassword from test2-page and clicks buttonLogin from test2-page
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'user logs in with l: and p: and clicks' should show credentials that were submitted for logging in (Page Object style step)
     Given user goes to "test2-page"."pageTest2"
     When user logs in with l: "test2-page"."loginTest2" in "test2-page"."inputUsername" and p: "test2-page"."passwordTest2" in "test2-page"."inputPassword" and clicks "test2-page"."buttonLogin"
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'user logs in with l: and p: and clicks' should show credentials that were submitted for logging in (text style step)
     Given user goes to "test2-page"."pageTest2"
     When user logs in with l: loginTest2 from test2-page in inputUsername from test2-page and p: passwordTest2 from test2-page in inputPassword from test2-page and clicks buttonLogin from test2-page
-    Then blockCredentials text from test2-page should be "testUser1111"
+    Then blockCredentials from test2-page text should be "testUser1111"
 
   Scenario: 'user moves to' element should trigger its hovered state, 'text should contain' should verify the text
     When user goes to URL "http://localhost:8001/test1.html"
@@ -33,7 +33,7 @@ Feature: Running Cucumber with TestCafe - test "user ..." steps feature 2
   Scenario: 'user moves to' element should trigger its hovered state, 'text should contain' should verify the text (text style step)
     When user goes to URL "http://localhost:8001/test1.html"
     And user moves to titleTest1 from test-page
-    Then blockTextTest text from test-page should contain txtTest1 from test-page
+    Then blockTextTest from test-page text should contain txtTest1 from test-page
 
   Scenario: 'user moves to with an offset' should trigger element's hovered state
     When user goes to URL "http://localhost:8001/test1.html"


### PR DESCRIPTION
**This pull request fixes 'text should be', 'text should contain' text style steps to be consistent with page object style**

Details:
- moved the 'text' word inside step definitions: '... **text** from ...' -> '... from ... **text**'