### PR TITLE
Update node-testing-server to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -755,9 +755,9 @@
       "dev": true
     },
     "node-testing-server": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-testing-server/-/node-testing-server-1.3.3.tgz",
-      "integrity": "sha512-lWsBtER48sPGG0XzB3wJRQYzj1n/efQJ8tExnxA4KGsAXJ3nx+vJUBGa21vYPx0gEYzUSiREtuG3I0a5nllfIg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/node-testing-server/-/node-testing-server-1.4.2.tgz",
+      "integrity": "sha512-Z17O7XJauHly1UIPOeqPcKN4m6EcgFqVjZVzwjx79yEKtoKwTSsEgTwFOjXAVIB7TeuFb1HTMawTcb0lESUKNg==",
       "dev": true
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "eslint": "^6.8.0",
     "eslint-plugin-cucumber": "^1.4.0",
     "eslint-plugin-testcafe": "^0.2.1",
-    "node-testing-server": "^1.3.3"
+    "node-testing-server": "^1.4.2"
   }
 }


### PR DESCRIPTION
**This pull request updates node-testing-server dependency to 1.4.2**