### PR TITLE
Bump up node-testing-server to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -755,9 +755,9 @@
       "dev": true
     },
     "node-testing-server": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/node-testing-server/-/node-testing-server-1.4.2.tgz",
-      "integrity": "sha512-Z17O7XJauHly1UIPOeqPcKN4m6EcgFqVjZVzwjx79yEKtoKwTSsEgTwFOjXAVIB7TeuFb1HTMawTcb0lESUKNg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/node-testing-server/-/node-testing-server-1.5.1.tgz",
+      "integrity": "sha512-ax77XGCtTXOn7fh1ZjZBRYsGiOjKit6orSGLXw0ZFQqxiNvsABxEVuwtUIVejq3ej/UnLO341OYNzt7Ix/a0wQ==",
       "dev": true
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "eslint": "^6.8.0",
     "eslint-plugin-cucumber": "^1.4.0",
     "eslint-plugin-testcafe": "^0.2.1",
-    "node-testing-server": "^1.4.2"
+    "node-testing-server": "^1.5.1"
   }
 }


### PR DESCRIPTION
**This pull request bumps up node-testing-server to 1.5.1**