### PR TITLE
Update 'user reloads the page' step

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ When(
 );
 
 When('I/user reload(s) the page', async function (t) {
-    await t.eval(() => location.reload(true));
+    await t.eval(() => location.reload());
 });
 
 When('I/user click(s) {string}.{string}', async function (t, [page, element]) {


### PR DESCRIPTION
**This pull request updates 'user reloads the page' step**

Now `location.reload()` should be used without the `true` argument (forceReload flag was deprecated and removed from the spec https://www.w3.org/TR/html50/browsers.html#dom-location-reload)